### PR TITLE
remove needless "is" from selection string

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Additionally it supports the [MDAnalysis selection syntax](https://docs.mdanalys
 
 # using MDAnalysis selection string to output just Carbon atoms
 
-simulation.reporters.append(MDAReporter('traj.xyz',100, selection='name is C'))
+simulation.reporters.append(MDAReporter('traj.xyz',100, selection='name C'))
 ```
 
 # Example


### PR DESCRIPTION
hey @sef43 this is very cool.  One thing I spotted was that the example selection looks a little odd.  The syntax is just `"name X [Y Z]"` for select all atoms with name(s) X (or Y or Z).  The current example is selecting atoms called `is` or `C`, which will work but isn't what you intended