### PR TITLE
Fix error in velocity reporting for nc and ncdf file types.

### DIFF
--- a/mdareporter/mdareporter.py
+++ b/mdareporter/mdareporter.py
@@ -113,7 +113,7 @@ class MDAReporter(object):
             positions, velocities, forces = True, True, True
         elif ext in ["ncdf", "nc"]:
             positions = True
-            velocities = self._writer_kwargs.get("positions", False)
+            velocities = self._writer_kwargs.get("velocities", False)
             forces = self._writer_kwargs.get("forces", False)
         elif ext in ["h5md"]:
             positions = self._writer_kwargs.get("positions", True)


### PR DESCRIPTION
Apologies, I made a typo in my last PR and put "positions" instead of "velocities". This one word PR fixes that issue.